### PR TITLE
Update  BeautifualSoap text to string

### DIFF
--- a/NetblockTool.py
+++ b/NetblockTool.py
@@ -1663,7 +1663,7 @@ def get_subsidiaries(company_name, verbose, alt_method, quiet):
                     if len(result_list) < 5:
                         result_list.clear()
                         key_tag = get_key_tag(soup, 1)
-                        soup_tags = soup.find_all(key_tag, text=True)
+                        soup_tags = soup.find_all(key_tag, string=True)
                         for tag in soup_tags:
                             filter_result = process_potential_company(tag.text, str(sub_list[0]))
                             if filter_result:
@@ -1672,7 +1672,7 @@ def get_subsidiaries(company_name, verbose, alt_method, quiet):
                         if len(result_list) < 5:
                             result_list.clear()
                             key_tag = get_key_tag(soup, 2)
-                            soup_tags = soup.find_all(key_tag, text=True)
+                            soup_tags = soup.find_all(key_tag, string=True)
                             for tag in soup_tags:
                                 filter_result = process_potential_company(tag.text, str(sub_list[0]))
                                 if filter_result:
@@ -1681,7 +1681,7 @@ def get_subsidiaries(company_name, verbose, alt_method, quiet):
                             ###  low number of subsidiaries, so return the original list
                             if len(result_list) < 5:
                                 result_list.clear()
-                                soup_tags = soup.find_all('font', text=True)
+                                soup_tags = soup.find_all('font', string=True)
                                 for tag in soup_tags:
                                     filter_result = process_potential_company(tag.text, str(sub_list[0]))
                                     if filter_result:
@@ -1692,14 +1692,14 @@ def get_subsidiaries(company_name, verbose, alt_method, quiet):
                         result_list3 = []
                         ### Try alternative tags to see if more accurate - 1st frequent tag
                         key_tag = get_key_tag(soup, 1)
-                        soup_tags = soup.find_all(key_tag, text=True)
+                        soup_tags = soup.find_all(key_tag, string=True)
                         for tag in soup_tags:
                             filter_result = process_potential_company(tag.text, str(sub_list[0]))
                             if filter_result:
                                 result_list2.append(filter_result)
                         ### Try alternative tags to see if more accurate - 2nd frequent tag
                         key_tag = get_key_tag(soup, 2)
-                        soup_tags = soup.find_all(key_tag, text=True)
+                        soup_tags = soup.find_all(key_tag, string=True)
                         for tag in soup_tags:
                             filter_result = process_potential_company(tag.text, str(sub_list[0]))
                             if filter_result:
@@ -1821,7 +1821,7 @@ def get_google_networks(target, verbose, quiet):
             continue_scrape = False
         try:
             soup_b = BeautifulSoup(req.text, 'html.parser')
-            for tag in soup_b.find_all('b', text=True):
+            for tag in soup_b.find_all('b', string=True):
                 if search_term == tag.text:
                     continue_scrape = False
                     if verbose:
@@ -1870,7 +1870,7 @@ def get_nethandle(url):
     # Request nethandle and process
     handle_req = requests.get(url, headers=headers)
     soup_pre = BeautifulSoup(handle_req.text, 'html.parser')
-    for tag in soup_pre.find_all('pre', text=True):
+    for tag in soup_pre.find_all('pre', string=True):
         if 'NetHandle' in tag.text:
             for x in range(0,str(tag.text).count('\n')+1):
                 line = str(tag.text).split('\n')[x]

--- a/NetblockTool.py
+++ b/NetblockTool.py
@@ -1240,7 +1240,7 @@ def get_asn_subnets(asn):
                'Connection'    : 'close'}
     req = requests.get('https://ipinfo.io/'+process_url_encode(asn), headers=headers)
     soup = BeautifulSoup(req.text, 'html.parser')
-    for a in soup.find_all('a', text=True):
+    for a in soup.find_all('a', string=True):
         if asn in str(a):
             return_list.append(str(a.text).strip())
     if return_list:
@@ -1654,7 +1654,7 @@ def get_subsidiaries(company_name, verbose, alt_method, quiet):
                         print('    [*] Parsing subsidiaries')
                     subsid_page = requests.get(subsid_url, headers={'User-Agent': USER_AGENT})
                     soup = BeautifulSoup(subsid_page.text, 'html.parser')
-                    soup_tags = soup.find_all('font', text=True)
+                    soup_tags = soup.find_all('font', string=True)
                     for tag in soup_tags:
                         filter_result = process_potential_company(tag.text, str(sub_list[0]))
                         if filter_result:


### PR DESCRIPTION
When running the tool the following error shows:
/home/USER/tools//NetblockTool/NetblockTool.py:1824: DeprecationWarning: The 'text' argument to find()-type methods is deprecated. Use 'string' instead.
  for tag in soup_b.find_all('b', text=True):

This is from this bug report:
https://bugs.launchpad.net/beautifulsoup/+bug/1947038

change log comment:
* Some time ago, the misleadingly named "text" argument to find-type
methods was renamed to the more accurate "string." But this supposed
"renaming" didn't make it into important places like the method
signatures or the docstrings. That's corrected in this
version. "text" still works, but will give a DeprecationWarning.
[bug=1947038]
(https://pyup.io/packages/pypi/beautifulsoup4/changelog)

I did find and replace for 'text=' to 'string='